### PR TITLE
Undefined name: from scipy.interpolate import LinearNDInterpolator

### DIFF
--- a/kitti_eval/depth_evaluation_utils.py
+++ b/kitti_eval/depth_evaluation_utils.py
@@ -2,6 +2,7 @@
 # https://github.com/mrharicot/monodepth/blob/master/utils/evaluation_utils.py
 import numpy as np
 # import pandas as pd
+from scipy.interpolate import LinearNDInterpolator
 import os
 import cv2
 from collections import Counter


### PR DESCRIPTION
[__LinearNDInterpolator()__](http://scipy.github.io/devdocs/generated/scipy.interpolate.LinearNDInterpolator.html#scipy.interpolate.LinearNDInterpolator) is called on line 122 but it is never defined or imported.